### PR TITLE
overcome bad SSL certificate

### DIFF
--- a/nextcloud_share_url_downloader.sh
+++ b/nextcloud_share_url_downloader.sh
@@ -133,6 +133,7 @@ list_content_nextcloud_share_url () {
     curl \
         -s \
         -u "${nextcloud_share_token}:${nextcloud_share_password}" \
+        --insecure \
         -H 'X-Requested-With: XMLHttpRequest' \
         -X PROPFIND \
         --data \
@@ -212,6 +213,7 @@ download_file_from_nextcloud_share () {
         curl \
             -C - \
             -u "${nextcloud_share_token}:${nextcloud_share_password}" \
+            --insecure \
             -H 'X-Requested-With: XMLHttpRequest' \
             -o "${output_filename}" \
             "${nextcloud_webdav_file_url}";
@@ -226,6 +228,7 @@ download_file_from_nextcloud_share () {
         # Download file.
         curl \
             -u "${nextcloud_share_token}:${nextcloud_share_password}" \
+            --insecure \
             -H 'X-Requested-With: XMLHttpRequest' \
             -o "${output_filename}" \
             "${nextcloud_webdav_file_url}";


### PR DESCRIPTION
See issue #3 

Adding argument `--insecure` to ignore the bad SSL certificate of `nextnuc.gbiomed.kuleuven.be`. Might be redundant in the future if they update their certificate.

But does the trick as a temporary solution. 